### PR TITLE
Remove not needed _providers.tf file

### DIFF
--- a/_providers.tf
+++ b/_providers.tf
@@ -1,1 +1,0 @@
-provider "aws" {}


### PR DESCRIPTION
The included `_providers.tf` is blocking its usage in Terragrunt:

```
There are some problems with the configuration, described below.                                                                                                                                            
                                                                                                                                                                                                            The Terraform configuration must be valid before initialization so that
Terraform can determine which modules and providers need to be installed.

Error: Duplicate provider configuration

  on provider.tf line 2:
   2: provider "aws" {

A default (non-aliased) provider configuration for "aws" was already given at
_providers.tf:1,1-15. If multiple configurations are required, set the "alias"
argument for alternative configurations.
```

IMHO, the `provider` configuration should be provided by the user when using this module.